### PR TITLE
Added 3 diverse tests

### DIFF
--- a/test/mocks/MockPufferOracle.sol
+++ b/test/mocks/MockPufferOracle.sol
@@ -52,7 +52,9 @@ contract MockPufferOracle is IPufferOracle {
 
     function getValidatorTicketPrice() external view returns (uint256 pricePerVT) { }
 
-    function getLockedEthAmount() external view returns (uint256 lockedEthAmount) { }
+    function getLockedEthAmount() external view returns (uint256 lockedEthAmount) {
+        return lockedETH;
+    }
 
     function isOverBurstThreshold() external view returns (bool) { }
 }


### PR DESCRIPTION
Done:
- 3 diverse tests, which means that there are many things to do around them:
  - Oracle integration
  - Daily withdrawal limit - math is a bit off, but easy to cure with proper `setUp` function
  - Pause
- Got familiar with a fairly the most of the code
Please refer to the code for explanation of each test

Not yet don, but would do next:
- I launch tests from `test_upgrade_to_mainnet`, and I use it as an entry point. **Bonk!** I thought I wouldn't waste time on setting up a new file, where `test_upgrade_to_mainnet` is a `setUp` - but that's what I would do first) - low hanging fruit
- Post upgrade getters unit test - low hanging fruit
- I spent quite some time attempting to test `callValue` restriction in `totalAssets` of the `PufferVaultMainnet.sol`, but decided to give a go the rest of the things first
- A lot to be done in the govenrance testing - also would give it a fairly high priority
- Many other things to do, but I tried to give 3 separate tests a go for a bit of diversity.
- Generally clean this code for a proper merge, but I was concentrated mostly on getting what the whole codebase is all about, and then just did 3 diverse things to not do it "onesided"